### PR TITLE
fix: hide selected text popup on updated Zhihu UI

### DIFF
--- a/src/components/hidden/append-style.ts
+++ b/src/components/hidden/append-style.ts
@@ -1,9 +1,51 @@
 import { fnAppendStyle, myStorage } from '../../tools';
 import { HIDDEN_ARRAY, HIDDEN_ARRAY_MORE } from './configs';
 
+let hiddenSelectedTextPopupEnabled = false;
+let hiddenSelectedTextPopupInited = false;
+let hiddenSelectedTextPopupTimer = 0;
+
+const hideSelectedTextPopup = () => {
+  if (!hiddenSelectedTextPopupEnabled) return;
+
+  document.querySelectorAll<HTMLElement>('[class^="css-"],[class*=" css-"],.Popover-content').forEach((item) => {
+    const rect = item.getBoundingClientRect();
+    if (rect.width <= 0 || rect.width > 500 || rect.height <= 0 || rect.height > 160) return;
+
+    const text = `${item.innerText}${item.innerHTML}`;
+    if (
+      (/复制/.test(text) && /(搜索|划线|直答|分享|引用|想法|评论|AI\s*解释)/.test(text)) ||
+      (/ZDI--Repeat24/.test(text) && /ZDI--Heart24/.test(text) && /ZDI--ChatBubble24/.test(text)) ||
+      /Zi--Copy/.test(text)
+    ) {
+      item.style.setProperty('display', 'none', 'important');
+    }
+  });
+};
+
+const scheduleHideSelectedTextPopup = () => {
+  window.clearTimeout(hiddenSelectedTextPopupTimer);
+  hiddenSelectedTextPopupTimer = window.setTimeout(hideSelectedTextPopup, 0);
+};
+
+const initHiddenSelectedTextPopup = () => {
+  if (hiddenSelectedTextPopupInited) return;
+  if (!document.body) {
+    window.setTimeout(initHiddenSelectedTextPopup, 100);
+    return;
+  }
+
+  hiddenSelectedTextPopupInited = true;
+  document.addEventListener('selectionchange', scheduleHideSelectedTextPopup);
+  document.addEventListener('mouseup', scheduleHideSelectedTextPopup, true);
+  new MutationObserver(scheduleHideSelectedTextPopup).observe(document.body, { childList: true, subtree: true });
+};
+
 /** 加载隐藏模块的样式 */
 export const appendHiddenStyle = async () => {
   const config = await myStorage.getConfig();
+  hiddenSelectedTextPopupEnabled = !!config.hiddenSelectedTextPopup;
+  hiddenSelectedTextPopupEnabled && initHiddenSelectedTextPopup();
 
   let hiddenContent = '';
 

--- a/src/components/hidden/configs.ts
+++ b/src/components/hidden/configs.ts
@@ -24,7 +24,14 @@ const HIDDEN_ITEM_COMMON: IHiddenItem = {
       {
         label: '隐藏选中文字后的弹窗模块',
         value: 'hiddenSelectedTextPopup',
-        css: '.css-s3a8u1{display: none!important;}',
+        css:
+          '.css-s3a8u1{display: none!important;}' +
+          ':is([class^="css-"],[class*=" css-"]):has(button[aria-label*="复制"]):has(button:nth-of-type(2)),' +
+          ':is([class^="css-"],[class*=" css-"]):has(button svg[class*="Zi--Copy"]):has(button:nth-of-type(2)),' +
+          '.Popover-content:has(button[aria-label*="复制"]):has(button:nth-of-type(2)),' +
+          '.Popover-content:has(button svg[class*="Zi--Copy"]):has(button:nth-of-type(2)),' +
+          '.css-ykbyph,' +
+          ':is([class^="css-"],[class*=" css-"]):has(.ZDI--Repeat24):has(.ZDI--Heart24):has(.ZDI--ChatBubble24){display: none!important;}',
       }
     ],
     [


### PR DESCRIPTION
## Summary
- keep the existing `.css-s3a8u1` selector and add selectors for the newer selected-text popup structure
- add a small runtime fallback that hides small floating selected-text action menus when the setting is enabled

## Root cause
Zhihu's selected-text popup no longer uses only the previous `.css-s3a8u1` class/button-based structure. On current Chrome it can render as a small floating menu with actions like 复制/喜欢/评论/AI 解释 and icons including `ZDI--Repeat24`, `ZDI--Heart24`, and `ZDI--ChatBubble24`.

## Validation
- Verified against the current Zhihu selected-text popup DOM on Chrome
- `node --check index.js`
- `git diff --check`

Fixes #179
